### PR TITLE
Selectize Renderable ChoiceObjMap and custom templating.

### DIFF
--- a/assets/src/scripts/charcoal/admin/widget/form.js
+++ b/assets/src/scripts/charcoal/admin/widget/form.js
@@ -17,6 +17,8 @@ Charcoal.Admin.Widget_Form = function (opts) {
     this.widget_id         = null;
     this.obj_type          = null;
     this.obj_id            = null;
+    this.save_action       = 'object/save';
+    this.update_action     = 'object/update';
     this.form_selector     = null;
     this.form_working      = false;
     this.submitted_via     = null;
@@ -322,9 +324,9 @@ Charcoal.Admin.Widget_Form.prototype.enable_button = function ($trigger) {
  */
 Charcoal.Admin.Widget_Form.prototype.request_url = function () {
     if (this.is_new_object) {
-        return Charcoal.Admin.admin_url() + 'object/save';
+        return Charcoal.Admin.admin_url() + this.save_action;
     } else {
-        return Charcoal.Admin.admin_url() + 'object/update';
+        return Charcoal.Admin.admin_url() + this.update_action;
     }
 };
 

--- a/assets/src/scripts/charcoal/admin/widget/quickform.js
+++ b/assets/src/scripts/charcoal/admin/widget/quickform.js
@@ -10,6 +10,11 @@ Charcoal.Admin.Widget_Quick_Form = function (opts) {
     this.widget_type = 'charcoal/admin/widget/quick-form';
     this.save_callback = opts.save_callback || '';
     this.cancel_callback = opts.cancel_callback || '';
+
+    this.save_action   = opts.save_action || 'object/save';
+    this.update_action = opts.update_action || 'object/update';
+    this.extra_form_data = opts.extra_form_data || {};
+
     this.form_working = false;
     this.suppress_feedback = opts.suppress_feedback || false;
     this.is_new_object = false;
@@ -68,6 +73,14 @@ Charcoal.Admin.Widget_Quick_Form.prototype.submit_form = function (form) {
     form_data = new FormData(form);
 
     this.disable_form($form, $trigger);
+
+    var extraFormData = this.extra_form_data;
+
+    for (var data in extraFormData) {
+        if (extraFormData.hasOwnProperty(data)){
+            form_data.append(data, extraFormData[data]);
+        }
+    }
 
     this.xhr = $.ajax({
         type: 'POST',

--- a/config/admin.config.default.json
+++ b/config/admin.config.default.json
@@ -72,6 +72,12 @@
             "object/update": {
                 "ident": "charcoal/admin/action/object/update"
             },
+            "selectize/save": {
+                "ident": "charcoal/admin/action/selectize/save"
+            },
+            "selectize/update": {
+                "ident": "charcoal/admin/action/selectize/update"
+            },
             "object/reorder": {
                 "ident": "charcoal/admin/action/object/reorder"
             },
@@ -85,6 +91,10 @@
             "object/load": {
                 "methods": [ "GET", "POST" ],
                 "ident": "charcoal/admin/action/object/load"
+            },
+            "selectize/load": {
+                "methods": [ "GET", "POST" ],
+                "ident": "charcoal/admin/action/selectize/load"
             },
             "widget/load": {
                 "ident": "charcoal/admin/action/widget/load"

--- a/src/Charcoal/Admin/Action/Object/LoadAction.php
+++ b/src/Charcoal/Admin/Action/Object/LoadAction.php
@@ -97,6 +97,8 @@ class LoadAction extends AdminAction
             '{{ parameter }} required, must be a {{ expectedType }}, received {{ actualType }}'
         );
 
+        $this->setData($request->getParams());
+
         $objType = $request->getParam('obj_type');
         $objId   = $request->getParam('obj_id');
 

--- a/src/Charcoal/Admin/Action/Selectize/LoadAction.php
+++ b/src/Charcoal/Admin/Action/Selectize/LoadAction.php
@@ -27,26 +27,6 @@ class LoadAction extends DefaultLoadAction
     }
 
     /**
-     * Sets the entity data, from associative array map (or any other Traversable).
-     *
-     * This function takes an array and fill the property with its value.
-     *
-     * @param array $data The entity data. Will call setters.
-     * @return self Chainable
-     * @see self::offsetSet()
-     */
-    public function setData(array $data)
-    {
-        parent::setData($data);
-
-        if (isset($data['selectize_input_ident'])) {
-            error_log(var_export($data['selectize_prop_ident'], true));
-        }
-
-        return $this;
-    }
-
-    /**
      * Fetch ids from Object Collection.
      *
      * @return array

--- a/src/Charcoal/Admin/Action/Selectize/LoadAction.php
+++ b/src/Charcoal/Admin/Action/Selectize/LoadAction.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Charcoal\Admin\Action\Selectize;
+
+use Charcoal\Admin\Action\Object\LoadAction as DefaultLoadAction;
+use Charcoal\Admin\Service\SelectizeRenderer;
+use Pimple\Container;
+
+/**
+ * Selectize Load Action
+ */
+class LoadAction extends DefaultLoadAction
+{
+    use SelectizeRendererAwareTrait;
+
+    /**
+     * Dependencies
+     * @param Container $container DI Container.
+     * @return void
+     */
+    public function setDependencies(Container $container)
+    {
+        parent::setDependencies($container);
+
+        $this->setSelectizeRenderer($container['selectize/renderer']);
+        $this->setPropertyInputFactory($container['property/input/factory']);
+    }
+
+    /**
+     * Sets the entity data, from associative array map (or any other Traversable).
+     *
+     * This function takes an array and fill the property with its value.
+     *
+     * @param array $data The entity data. Will call setters.
+     * @return self Chainable
+     * @see self::offsetSet()
+     */
+    public function setData(array $data)
+    {
+        parent::setData($data);
+
+        if (isset($data['selectize_input_ident'])) {
+            error_log(var_export($data['selectize_prop_ident'], true));
+        }
+
+        return $this;
+    }
+
+    /**
+     * Fetch ids from Object Collection.
+     *
+     * @return array
+     */
+    private function parseCollectionIds()
+    {
+        $collection = $this->objCollection();
+        $ids = [];
+
+        foreach ($collection as $object) {
+            $ids[] = $object->id();
+        }
+
+        return $ids;
+    }
+
+    /**
+     * @return array
+     */
+    public function results()
+    {
+        $results = parent::results();
+
+        if ($this->success() === true) {
+            $results['selectize'] = $this->selectizeVal($this->parseCollectionIds());
+        }
+
+        return $results;
+    }
+}

--- a/src/Charcoal/Admin/Action/Selectize/SaveAction.php
+++ b/src/Charcoal/Admin/Action/Selectize/SaveAction.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Charcoal\Admin\Action\Selectize;
+
+use Charcoal\Admin\Action\Object\SaveAction as DefaultSaveAction;
+use Charcoal\Admin\Service\SelectizeRenderer;
+use Charcoal\Model\ModelInterface;
+use Pimple\Container;
+
+/**
+ * Selectize Save Action
+ */
+class SaveAction extends DefaultSaveAction
+{
+    use SelectizeRendererAwareTrait;
+
+    /**
+     * Dependencies
+     * @param Container $container DI Container.
+     * @return void
+     */
+    public function setDependencies(Container $container)
+    {
+        parent::setDependencies($container);
+
+        $this->setSelectizeRenderer($container['selectize/renderer']);
+        $this->setPropertyInputFactory($container['property/input/factory']);
+    }
+
+    /**
+     * @return array
+     */
+    public function results()
+    {
+        $results = parent::results();
+
+        if ($this->success() === true) {
+            $results['selectize'] = $this->selectizeVal($this->obj()->id());
+        }
+
+        return $results;
+    }
+}

--- a/src/Charcoal/Admin/Action/Selectize/SelectizeRendererAwareTrait.php
+++ b/src/Charcoal/Admin/Action/Selectize/SelectizeRendererAwareTrait.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace Charcoal\Admin\Action\Selectize;
+
+// Dependencies from `charcoal-admin`
+use Charcoal\Admin\Property\Input\SelectizeInput;
+use Charcoal\Admin\Property\PropertyInputInterface;
+use Charcoal\Admin\Service\SelectizeRenderer;
+
+// Dependencies from `charcoal-factory`
+use Charcoal\Factory\FactoryInterface;
+
+// Dependencies from `charcoal-property`
+use Charcoal\Property\PropertyInterface;
+
+// PSR-7 dependencies
+use RuntimeException;
+
+trait SelectizeRendererAwareTrait
+{
+    /**
+     * @var SelectizeRenderer
+     */
+    protected $selectizeRenderer;
+
+    /**
+     * Store the factory instance.
+     *
+     * @var FactoryInterface
+     */
+    protected $propertyInputFactory;
+
+    /**
+     * @var string
+     */
+    protected $selectizeObjType;
+
+    /**
+     * @var string
+     */
+    protected $selectizePropIdent;
+
+    /**
+     * @var PropertyInterface
+     */
+    protected $selectizeProperty;
+
+    /**
+     * @return PropertyInterface
+     */
+    protected function selectizeProperty()
+    {
+        if ($this->selectizeProperty) {
+            return $this->selectizeProperty;
+        }
+
+        $objType = $this->selectizeObjType();
+        $propertyIdent = $this->selectizePropIdent();
+
+        if ($objType && $propertyIdent) {
+            $model = $this->modelFactory()->create($objType);
+            $prop = $model->property($propertyIdent);
+
+            $this->selectizeProperty = $prop;
+        }
+
+        return $this->selectizeProperty;
+    }
+
+    /**
+     * @return PropertyInputInterface
+     */
+    protected function selectizeInput()
+    {
+        $prop = $this->selectizeProperty();
+        $type = isset($prop['input_type']) ? $prop['input_type'] : null;
+
+        $input = $this->propertyInputFactory()->create($type);
+        $input->setInputType($type);
+        $input->setProperty($prop);
+        $input->setData($prop->data());
+
+        return $input;
+    }
+
+    /**
+     * Retrieves the output from SelectizeInput::selectizeVal.
+     *
+     * @param mixed $val The value(s) to parse as selectize choices.
+     * @return array
+     */
+    protected function selectizeVal($val)
+    {
+        if ($val === null) {
+            return [];
+        }
+
+        $input = $this->selectizeInput();
+        $choices = [];
+
+        if ($input instanceof SelectizeInput) {
+            $choices = $input->selectizeVal($val);
+        }
+
+        return $choices;
+    }
+
+    // ==========================================================================
+    // SUPPORT
+    // ==========================================================================
+
+    /**
+     * Set a property control factory.
+     *
+     * @param  FactoryInterface $factory The factory to create form controls for property values.
+     * @return self
+     */
+    protected function setPropertyInputFactory(FactoryInterface $factory)
+    {
+        $this->propertyInputFactory = $factory;
+
+        return $this;
+    }
+
+    /**
+     * Retrieve the property control factory.
+     *
+     * @throws RuntimeException If the property control factory is missing.
+     * @return FactoryInterface
+     */
+    public function propertyInputFactory()
+    {
+        if (!isset($this->propertyInputFactory)) {
+            throw new RuntimeException(sprintf(
+                'Property Control Factory is not defined for [%s]',
+                get_class($this)
+            ));
+        }
+
+        return $this->propertyInputFactory;
+    }
+
+    // ==========================================================================
+    // GETTERS AND SETTERS
+    // ==========================================================================
+
+    /**
+     * @param string $data The data set by setData().
+     * @return $this
+     */
+    public function setSelectizeObjType($data)
+    {
+        $this->selectizeObjType = $data;
+
+        return $this;
+    }
+
+    /**
+     * @param string $data The data set by setData().
+     * @return $this
+     */
+    public function setSelectizePropIdent($data)
+    {
+        $this->selectizePropIdent = $data;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function selectizeObjType()
+    {
+        return $this->selectizeObjType;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function selectizePropIdent()
+    {
+        return $this->selectizePropIdent;
+    }
+
+    /**
+     * @return SelectizeRenderer
+     */
+    public function selectizeRenderer()
+    {
+        return $this->selectizeRenderer;
+    }
+
+    /**
+     * @param SelectizeRenderer $selectizeRenderer Selectize renderer.
+     * @return self
+     */
+    public function setSelectizeRenderer(SelectizeRenderer $selectizeRenderer)
+    {
+        $this->selectizeRenderer = $selectizeRenderer;
+
+        return $this;
+    }
+
+    /**
+     * @throws Exception If the model factory was not set before being accessed.
+     * @return FactoryInterface
+     */
+    abstract protected function modelFactory();
+}

--- a/src/Charcoal/Admin/Action/Selectize/UpdateAction.php
+++ b/src/Charcoal/Admin/Action/Selectize/UpdateAction.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Charcoal\Admin\Action\Selectize;
+
+use Charcoal\Admin\Action\Object\UpdateAction as DefaultUpdateAction;
+use Charcoal\Admin\Service\SelectizeRenderer;
+use Pimple\Container;
+
+/**
+ * Selectize Update Action
+ */
+class UpdateAction extends DefaultUpdateAction
+{
+    use SelectizeRendererAwareTrait;
+
+    /**
+     * Dependencies
+     * @param Container $container DI Container.
+     * @return void
+     */
+    public function setDependencies(Container $container)
+    {
+        parent::setDependencies($container);
+
+        $this->setSelectizeRenderer($container['selectize/renderer']);
+        $this->setPropertyInputFactory($container['property/input/factory']);
+    }
+
+    /**
+     * @return array
+     */
+    public function results()
+    {
+        $results = parent::results();
+
+        if ($this->success() === true) {
+            $results['selectize'] = $this->selectizeVal($this->obj()->id());
+        }
+
+        return $results;
+    }
+}

--- a/src/Charcoal/Admin/Property/AbstractSelectableInput.php
+++ b/src/Charcoal/Admin/Property/AbstractSelectableInput.php
@@ -2,6 +2,8 @@
 
 namespace Charcoal\Admin\Property;
 
+use Charcoal\View\ViewableInterface;
+use Charcoal\View\ViewInterface;
 use Closure;
 use DateTimeInterface;
 use InvalidArgumentException;
@@ -199,9 +201,50 @@ abstract class AbstractSelectableInput extends AbstractPropertyInput implements
     }
 
     /**
+     * Render the given object.
+     *
+     * @param  ModelInterface|ViewableInterface $obj  The object or view to render as a label.
+     * @param  string|null                      $prop Optional. The render pattern to render.
+     * @throws InvalidArgumentException If the prop is not a string.
+     * @return mixed|string
+     */
+    protected function renderChoiceObjMap($obj, $prop)
+    {
+        if (!is_string($prop)) {
+            throw new InvalidArgumentException(
+                'The render pattern must be a string.'
+            );
+        }
+
+        if ($prop === '') {
+            return '';
+        }
+
+        if (strpos($prop, '{{') === false) {
+            if (isset($obj[$prop])) {
+                return $this->parseChoiceVal($obj[$prop]);
+            }
+        }
+
+        if (($obj instanceof ViewableInterface) && ($obj->view() instanceof ViewInterface)) {
+            return $obj->renderTemplate($prop);
+        } else {
+            $callback = function ($matches) use ($obj) {
+                $prop = trim($matches[1]);
+                if (isset($obj[$prop])) {
+                    return $this->parseChoiceVal($obj[$prop]);
+                }
+                return [];
+            };
+
+            return preg_replace_callback('~\{\{\s*(.*?)\s*\}\}~i', $callback, $prop);
+        }
+    }
+
+    /**
      * Convert the given object into a choice structure.
      *
-     * @param  array|\ArrayAccess $obj The object to map to a choice.
+     * @param  array|\ArrayAccess|ModelInterface $obj The object to map to a choice.
      * @return array
      */
     public function mapObjToChoice($obj)
@@ -215,10 +258,8 @@ abstract class AbstractSelectableInput extends AbstractPropertyInput implements
 
             $props = explode(':', $props);
             foreach ($props as $prop) {
-                if (isset($obj[$prop])) {
-                    $choice[$key] = $this->parseChoiceVal($obj[$prop]);
-                    break;
-                }
+                $choice[$key] = $this->renderChoiceObjMap($obj, $prop);
+                break;
             }
         }
 

--- a/src/Charcoal/Admin/Property/AbstractSelectableInput.php
+++ b/src/Charcoal/Admin/Property/AbstractSelectableInput.php
@@ -70,9 +70,9 @@ abstract class AbstractSelectableInput extends AbstractPropertyInput implements
         }
 
         if (isset($choice['label'])) {
-            $choice['label'] = $this->translator()->translation($choice['label']);
+            $choice['label'] = (string)$this->translator()->translation($choice['label']);
         } else {
-            $choice['label'] = $this->translator()->translation($choice['value']);
+            $choice['label'] = (string)$this->translator()->translation($choice['value']);
         }
 
         $choice['checked'] = $this->isChoiceSelected($choice);

--- a/src/Charcoal/Admin/Property/Input/SelectInput.php
+++ b/src/Charcoal/Admin/Property/Input/SelectInput.php
@@ -57,9 +57,9 @@ class SelectInput extends AbstractSelectableInput
         $choice = parent::parseChoice($ident, $choice);
 
         if (isset($choice['title'])) {
-            $choice['title'] = $this->translator()->translation($choice['title']);
+            $choice['title'] = (string)$this->translator()->translation($choice['title']);
         } else {
-            $choice['title'] = $this->translator()->translation($choice['label']);
+            $choice['title'] = (string)$this->translator()->translation($choice['label']);
         }
 
         if (!isset($choice['subtext'])) {

--- a/src/Charcoal/Admin/Service/SelectizeRenderer.php
+++ b/src/Charcoal/Admin/Service/SelectizeRenderer.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Charcoal\Admin\Service;
+
+use Charcoal\Cms\TemplateableTrait;
+use Charcoal\Factory\FactoryInterface;
+use Charcoal\Model\ModelInterface;
+use Charcoal\Translator\TranslatorAwareTrait;
+use Charcoal\View\ViewInterface;
+use Exception;
+use Psr\Log\LoggerAwareTrait;
+
+/**
+ * Renders a template given the object meta or template controller.
+ *
+ * Selectize renderer service
+ */
+class SelectizeRenderer
+{
+    use TranslatorAwareTrait;
+    use TemplateableTrait;
+    use LoggerAwareTrait;
+
+    /**
+     * Template Factory
+     *
+     * @var FactoryInterface
+     */
+    private $templateFactory;
+
+    /**
+     * @var ViewInterface
+     */
+    private $view;
+
+    /**
+     * PHP 5 allows developers to declare constructor methods for classes.
+     * Classes which have a constructor method call this method on each newly-created object,
+     * so it is suitable for any initialization that the object may need before it is used.
+     *
+     * Note: Parent constructors are not called implicitly if the child class defines a constructor.
+     * In order to run a parent constructor, a call to parent::__construct() within the child constructor is required.
+     *
+     * @param array $data Dependencies.
+     * @throws Exception If missing dependencies.
+     * @return self
+     * @link http://php.net/manual/en/language.oop5.decon.php
+     */
+    public function __construct(array $data)
+    {
+        if (!isset($data['logger'])) {
+            throw new Exception(
+                'You must set the logger in the Exporter Constructor.'
+            );
+        }
+
+        $this->logger = $data['logger'];
+        $this->templateFactory = $data['template_factory'];
+        $this->view = $data['view'];
+        $this->setTranslator($data['translator']);
+
+        return $this;
+    }
+
+    /**
+     * @param string         $templateIdent   The templateIdent as string.
+     * @param ModelInterface $object          The ObjectType for context.
+     * @param string|null    $controllerIdent The ControllerIdent string to override Object context.
+     * @throws \InvalidArgumentException If the callable id not callable.
+     * @return string
+     */
+    public function renderTemplate($templateIdent, ModelInterface $object, $controllerIdent = null)
+    {
+        $template = null;
+
+        if ($controllerIdent && is_string($controllerIdent)) {
+            $controllerIdent = explode('::', $controllerIdent);
+            $controllerCallable = isset($controllerIdent[1]) ? $controllerIdent[1] : null;
+            $controllerIdent = $controllerIdent[0];
+
+            $template = $this->templateFactory->create($controllerIdent);
+
+            if ($controllerCallable) {
+                $method = [ $template, $controllerCallable ];
+                if (!is_callable($method)) {
+                    throw new \InvalidArgumentException(sprintf(
+                        '%s::%s supplied in %s::%s is not a callable method.',
+                        $controllerIdent,
+                        $controllerCallable,
+                        __CLASS__,
+                        __FUNCTION__
+                    ));
+                }
+
+                call_user_func($method, $object);
+            } elseif (is_callable($template)) {
+                $template($object);
+            } else {
+                throw new \InvalidArgumentException(sprintf(
+                    '%s supplied in %s::%s is not callable.',
+                    get_class($template),
+                    __CLASS__,
+                    __FUNCTION__
+                ));
+            }
+        }
+
+        if (!$template) {
+            $template = $object;
+        }
+
+        return $this->view->render($templateIdent, $template);
+    }
+}

--- a/src/Charcoal/Admin/ServiceProvider/AdminServiceProvider.php
+++ b/src/Charcoal/Admin/ServiceProvider/AdminServiceProvider.php
@@ -4,6 +4,7 @@ namespace Charcoal\Admin\ServiceProvider;
 
 // From Pimple
 use Charcoal\Admin\Service\SelectizeRenderer;
+use Charcoal\Factory\FactoryInterface;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 
@@ -193,10 +194,10 @@ class AdminServiceProvider implements ServiceProviderInterface
         $container['property/input/factory'] = function (Container $container) {
             return new Factory([
                 'base_class'       => PropertyInputInterface::class,
-                'arguments'        => [ [
+                'arguments'        => [[
                     'container' => $container,
                     'logger'    => $container['logger']
-                ] ],
+                ]],
                 'resolver_options' => [
                     'suffix' => 'Input'
                 ]
@@ -210,10 +211,10 @@ class AdminServiceProvider implements ServiceProviderInterface
         $container['property/display/factory'] = function (Container $container) {
             return new Factory([
                 'base_class'       => PropertyDisplayInterface::class,
-                'arguments'        => [ [
+                'arguments'        => [[
                     'container' => $container,
                     'logger'    => $container['logger']
-                ] ],
+                ]],
                 'resolver_options' => [
                     'suffix' => 'Display'
                 ]
@@ -228,12 +229,12 @@ class AdminServiceProvider implements ServiceProviderInterface
             return new Factory([
                 'base_class'       => SidemenuGroupInterface::class,
                 'default_class'    => GenericSidemenuGroup::class,
-                'arguments'        => [ [
+                'arguments'        => [[
                     'container'      => $container,
                     'logger'         => $container['logger'],
                     'view'           => $container['view'],
                     'layout_builder' => $container['layout/builder']
-                ] ],
+                ]],
                 'resolver_options' => [
                     'suffix' => 'SidemenuGroup'
                 ]
@@ -254,9 +255,9 @@ class AdminServiceProvider implements ServiceProviderInterface
         $container->extend('view/mustache/helpers', function (array $helpers, Container $container) {
             $adminUrl = clone $container['base-url'];
             if ($container['admin/config']['base_path']) {
-                $basePath = rtrim($adminUrl->getBasePath(), '/');
+                $basePath  = rtrim($adminUrl->getBasePath(), '/');
                 $adminPath = ltrim($container['admin/config']['base_path'], '/');
-                $adminUrl = $adminUrl->withBasePath($basePath.'/'.$adminPath);
+                $adminUrl  = $adminUrl->withBasePath($basePath.'/'.$adminPath);
             }
 
             $urls = [
@@ -284,14 +285,14 @@ class AdminServiceProvider implements ServiceProviderInterface
                     } else {
                         $parts = parse_url($uri);
                         if (!isset($parts['scheme'])) {
-                            if (!in_array($uri[0], [ '/', '#', '?' ])) {
-                                $path = isset($parts['path']) ? ltrim($parts['path'], '/') : '';
+                            if (!in_array($uri[0], ['/', '#', '?'])) {
+                                $path  = isset($parts['path']) ? ltrim($parts['path'], '/') : '';
                                 $query = isset($parts['query']) ? $parts['query'] : '';
-                                $hash = isset($parts['fragment']) ? $parts['fragment'] : '';
+                                $hash  = isset($parts['fragment']) ? $parts['fragment'] : '';
 
                                 return $adminUrl->withPath($path)
-                                    ->withQuery($query)
-                                    ->withFragment($hash);
+                                                ->withQuery($query)
+                                                ->withFragment($hash);
                             }
                         }
                     }

--- a/templates/charcoal/admin/property/input/selectize.mustache
+++ b/templates/charcoal/admin/property/input/selectize.mustache
@@ -53,7 +53,7 @@
             data: {
                 title                 : '{{ label }}',
                 translations          : {
-                    statusTemplate: '{{#_t}}Step [[ current ]] of [[ total ]]{{/_t}}',
+                    statusTemplate: '{{#_t}}Step [[ current ]] of [[ total ]]{{/_t}}'
                 },
                 {{# property.objType }}
                     pattern           : '{{ pattern }}',
@@ -72,7 +72,10 @@
                 selectize_selector    : '#{{ inputId }}',
                 form_ident            : {{& formIdentAsJson}},
                 selectize_options     : {{& selectizeOptionsAsJson }},
-                choice_obj_map        : {{& choiceObjMapAsJson }}
+                choice_obj_map        : {{& choiceObjMapAsJson }},
+                selectize_property_ident : '{{& property.ident }}',
+                selectize_obj_type       : '{{& objType }}',
+                selectize_templates   : {{& selectizeTemplatesAsJson }}
             }
         });
     </script>


### PR DESCRIPTION
This adds 2 main options to selectize input : 

- the choiceObjMap is now mustache renderable
- and you can supply custom mustache templates for selectize to render.

Those 2 new features are possible through custom object actions specifically made for selectize that instantiate a SelectizeInput and returns a pre-formatted array to the selectize.js plugin that can be used as-is. The selectize.js will in fact receive an array `selectize` containing a `value, label, item_render and option_render` that can be directly set as a selectize item.

selectize_templates usage : 

```
"category": {
    "input_type": "charcoal/admin/property/input/selectize",
    "obj_type": "city/object/news-category",
    "form_ident": "city.quick",
    "selectize_templates": {
        "item": "project/selectize/custom-item-template",
        "option": "project/selectize/custom-option-template",
        "controller": "project/selectize/custom-template"
    }
}
```

Here the word `option` refers to a drop-down option in select.
The Controller is optional and the object controller will be used in the case that's it's not defined.

choice_obj_map usage :
```
"category": {
    "input_type": "charcoal/admin/property/input/selectize",
    "obj_type": "city/object/news-category",
    "form_ident": "city.quick",
    "choice_obj_map": {
        "value": "{{ident}}",
        "label": "{{customLabelFunction}} - {{someAdditionalInfo }}"
    }
}
```