### PR TITLE
Implement Support Traits

### DIFF
--- a/src/Charcoal/Admin/Action/ElfinderConnectorAction.php
+++ b/src/Charcoal/Admin/Action/ElfinderConnectorAction.php
@@ -39,13 +39,6 @@ class ElfinderConnectorAction extends AdminAction
     use CallableResolverAwareTrait;
 
     /**
-     * The base URI for the Charcoal application.
-     *
-     * @var UriInterface|string
-     */
-    protected $baseUrl;
-
-    /**
      * The relative path (from filesystem's root) to the storage directory.
      *
      * @var string
@@ -80,8 +73,6 @@ class ElfinderConnectorAction extends AdminAction
      * @var PropertyInterface
      */
     private $formProperty;
-
-
 
     /**
      * Retrieve the property factory.
@@ -530,5 +521,37 @@ class ElfinderConnectorAction extends AdminAction
             'hidden'  => true,
             'locked'  => false
         ];
+    }
+
+    /**
+     * Set a property factory.
+     *
+     * @param FactoryInterface $factory The property factory,
+     *                                  to createable property values.
+     * @return self
+     */
+    protected function setPropertyFactory(FactoryInterface $factory)
+    {
+        $this->propertyFactory = $factory;
+
+        return $this;
+    }
+
+    /**
+     * Retrieve the property factory.
+     *
+     * @throws RuntimeException If the property factory was not previously set.
+     * @return FactoryInterface
+     */
+    public function propertyFactory()
+    {
+        if (!isset($this->propertyFactory)) {
+            throw new RuntimeException(sprintf(
+                'Property Factory is not defined for "%s"',
+                get_class($this)
+            ));
+        }
+
+        return $this->propertyFactory;
     }
 }

--- a/src/Charcoal/Admin/AdminAction.php
+++ b/src/Charcoal/Admin/AdminAction.php
@@ -26,6 +26,9 @@ use Charcoal\App\Action\AbstractAction;
 
 // From 'charcoal-admin'
 use Charcoal\Admin\Ui\FeedbackContainerTrait;
+use Charcoal\Admin\Support\AdminTrait;
+use Charcoal\Admin\Support\BaseUrlTrait;
+use Charcoal\Admin\Support\SecurityTrait;
 
 /**
  * The base class for the `admin` Actions.
@@ -33,23 +36,12 @@ use Charcoal\Admin\Ui\FeedbackContainerTrait;
 abstract class AdminAction extends AbstractAction implements
     AuthAwareInterface
 {
+    use AdminTrait;
     use AuthAwareTrait;
+    use BaseUrlTrait;
     use FeedbackContainerTrait;
+    use SecurityTrait;
     use TranslatorAwareTrait;
-
-    /**
-     * Store a reference to the admin configuration.
-     *
-     * @var \Charcoal\Admin\Config
-     */
-    protected $adminConfig;
-
-    /**
-     * Store a reference to the application configuration.
-     *
-     * @var \Charcoal\App\AppConfig
-     */
-    protected $appConfig;
 
     /**
      * The name of the project.
@@ -122,38 +114,6 @@ abstract class AdminAction extends AbstractAction implements
     }
 
     /**
-     * Authentication is required by default.
-     *
-     * Reimplement and change to false in templates that do not require authentication.
-     *
-     * @return boolean
-     */
-    public function authRequired()
-    {
-        return true;
-    }
-
-    /**
-     * Determine if the current user is authenticated.
-     *
-     * @return boolean
-     */
-    public function isAuthenticated()
-    {
-        return !!$this->authenticator()->authenticate();
-    }
-
-    /**
-     * Retrieve the currently authenticated user.
-     *
-     * @return \Charcoal\User\UserInterface|null
-     */
-    public function getAuthenticatedUser()
-    {
-        return $this->authenticator()->authenticate();
-    }
-
-    /**
      * Default response stub.
      *
      * @return array
@@ -169,67 +129,44 @@ abstract class AdminAction extends AbstractAction implements
     }
 
     /**
-     * Retrieve the base URI of the administration area.
+     * Set common dependencies used in all admin actions.
      *
-     * @return UriInterface|string
-     */
-    public function adminUrl()
-    {
-        $adminPath = $this->adminConfig['base_path'];
-        return rtrim($this->baseUrl(), '/').'/'.rtrim($adminPath, '/').'/';
-    }
-
-    /**
-     * Set the base URI of the application.
-     *
-     * @param  UriInterface|string $uri The base URI.
-     * @return self
-     */
-    public function setBaseUrl($uri)
-    {
-        $this->baseUrl = $uri;
-        return $this;
-    }
-
-    /**
-     * Retrieve the base URI of the application.
-     *
-     * @return UriInterface|string
-     */
-    public function baseUrl()
-    {
-        return rtrim($this->baseUrl, '/').'/';
-    }
-
-    /**
-     * @param Container $container DI Container.
+     * @param  Container $container DI Container.
      * @return void
      */
     protected function setDependencies(Container $container)
     {
         parent::setDependencies($container);
 
-        $this->setModelFactory($container['model/factory']);
+        // Satisfies TranslatorAwareTrait dependencies
         $this->setTranslator($container['translator']);
 
-        $this->appConfig = $container['config'];
-        $this->adminConfig = $container['admin/config'];
-        $this->setBaseUrl($container['base-url']);
-        $this->setSiteName($container['config']['project_name']);
-
-        // Satisfies AuthAwareInterface dependencies
+        // Satisfies AuthAwareInterface + SecurityTrait dependencies
         $this->setAuthenticator($container['admin/authenticator']);
         $this->setAuthorizer($container['admin/authorizer']);
+
+        // Satisfies AdminTrait dependencies
+        $this->setDebug($container['config']);
+        $this->setAppConfig($container['config']);
+        $this->setAdminConfig($container['admin/config']);
+
+        // Satisfies BaseUrlTrait dependencies
+        $this->setBaseUrl($container['base-url']);
+        $this->setAdminUrl($container['admin/base-url']);
+
+
+        // Satisfies AdminAction dependencies
+        $this->setSiteName($container['config']['project_name']);
+        $this->setModelFactory($container['model/factory']);
     }
 
     /**
      * @param FactoryInterface $factory The factory used to create models.
-     * @return AdminScript Chainable
+     * @return void
      */
     protected function setModelFactory(FactoryInterface $factory)
     {
         $this->modelFactory = $factory;
-        return $this;
     }
 
     /**
@@ -262,7 +199,7 @@ abstract class AdminAction extends AbstractAction implements
     protected function validateCaptcha($response)
     {
         $validationUrl = 'https://www.google.com/recaptcha/api/siteverify';
-        $recaptcha = $this->appConfig['apis.google.recaptcha'];
+        $recaptcha = $this->appConfig('apis.google.recaptcha');
 
         if (isset($recaptcha['private_key'])) {
             $secret = $recaptcha['private_key'];

--- a/src/Charcoal/Admin/AdminModule.php
+++ b/src/Charcoal/Admin/AdminModule.php
@@ -95,7 +95,7 @@ class AdminModule extends AbstractModule
         ResponseInterface $response,
         callable $next
     ) {
-        $container   = $this->app()->getContainer();
+        $container = $this->app()->getContainer();
 
         /**
          * HTTP 404 (Not Found) handler.

--- a/src/Charcoal/Admin/AdminScript.php
+++ b/src/Charcoal/Admin/AdminScript.php
@@ -20,19 +20,16 @@ use Charcoal\Property\PropertyInterface;
 // From 'charcoal-translator'
 use Charcoal\Translator\TranslatorAwareTrait;
 
+// From 'charcoal-admin'
+use Charcoal\Admin\Support\BaseUrlTrait;
+
 /**
  *
  */
 abstract class AdminScript extends AbstractScript
 {
+    use BaseUrlTrait;
     use TranslatorAwareTrait;
-
-    /**
-     * The base URI.
-     *
-     * @var UriInterface
-     */
-    protected $baseUrl;
 
     /**
      * The model factory.
@@ -47,32 +44,17 @@ abstract class AdminScript extends AbstractScript
      */
     protected function setDependencies(Container $container)
     {
-        $this->setModelFactory($container['model/factory']);
-        $this->setTranslator($container['translator']);
-        $this->setBaseUrl($container['base-url']);
-
         parent::setDependencies($container);
-    }
 
+        // Satisfies TranslatorAwareTrait dependencies
+        $this->setTranslator($container['translator']);
 
-    /**
-     * Retrieve the model factory.
-     *
-     * @return FactoryInterface
-     */
-    protected function modelFactory()
-    {
-        return $this->modelFactory;
-    }
+        // Satisfies BaseUrlTrait dependencies
+        $this->setBaseUrl($container['base-url']);
+        $this->setAdminUrl($container['admin/base-url']);
 
-    /**
-     * Retrieve the base URI of the application.
-     *
-     * @return UriInterface|string
-     */
-    protected function baseUrl()
-    {
-        return rtrim($this->baseUrl, '/').'/';
+        // Satisfies AdminScript dependencies
+        $this->setModelFactory($container['model/factory']);
     }
 
     /**
@@ -142,17 +124,6 @@ abstract class AdminScript extends AbstractScript
     }
 
     /**
-     * Set the base URI of the application.
-     *
-     * @param  UriInterface|string $uri The base URI.
-     * @return void
-     */
-    private function setBaseUrl($uri)
-    {
-        $this->baseUrl = $uri;
-    }
-
-    /**
      * Set the model factory.
      *
      * @param  FactoryInterface $factory The factory used to create models.
@@ -161,5 +132,15 @@ abstract class AdminScript extends AbstractScript
     private function setModelFactory(FactoryInterface $factory)
     {
         $this->modelFactory = $factory;
+    }
+
+    /**
+     * Retrieve the model factory.
+     *
+     * @return FactoryInterface
+     */
+    protected function modelFactory()
+    {
+        return $this->modelFactory;
     }
 }

--- a/src/Charcoal/Admin/AdminTemplate.php
+++ b/src/Charcoal/Admin/AdminTemplate.php
@@ -569,6 +569,10 @@ class AdminTemplate extends AbstractTemplate implements
         }
 
         $mainMenu = null;
+        if (isset($this['header_menu_item'])){
+            $mainMenu = $this['header_menu_item'];
+        }
+
         if (!(empty($options) && !is_numeric($options))) {
             if (is_string($options)) {
                 $mainMenu = $options;
@@ -621,6 +625,14 @@ class AdminTemplate extends AbstractTemplate implements
             $options['widget_options']['ident'] = null;
         }
 
+        if (isset($this['side_menu_item'])) {
+            $options['widget_options']['current_item'] = $this['side_menu_item'];
+        }
+
+        if (isset($this['header_menu_item'])) {
+           $options['widget_options']['ident'] = $this['header_menu_item'];
+        }
+
         $sidemenuFromRequest = filter_input(INPUT_GET, 'side_menu', FILTER_SANITIZE_STRING);
         $mainMenuFromRequest = filter_input(INPUT_GET, 'main_menu', FILTER_SANITIZE_STRING);
         if ($sidemenuFromRequest) {
@@ -664,6 +676,10 @@ class AdminTemplate extends AbstractTemplate implements
         }
 
         $currentIdent = null;
+        if (isset($this['system_menu_item'])){
+            $currentIdent = $this['system_menu_item'];
+        }
+
         if (!(empty($options) && !is_numeric($options))) {
             if (is_string($options)) {
                 $currentIdent = $options;

--- a/src/Charcoal/Admin/Support/AdminTrait.php
+++ b/src/Charcoal/Admin/Support/AdminTrait.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Charcoal\Admin\Support;
+
+// From 'charcoal-app'
+use Charcoal\App\AppConfig;
+
+// From 'charcoal-admin'
+use Charcoal\Admin\Config as AdminConfig;
+
+/**
+ * Admin Support Trait
+ */
+trait AdminTrait
+{
+    /**
+     * Store a reference to the admin configuration.
+     *
+     * @var AdminConfig
+     */
+    protected $adminConfig;
+
+    /**
+     * Store a reference to the application configuration.
+     *
+     * @var AppConfig
+     */
+    protected $appConfig;
+
+    /**
+     * Whether the debug mode is enabled.
+     *
+     * @var boolean
+     */
+    private $debug = false;
+
+    /**
+     * Set application debug mode.
+     *
+     * @param  boolean $debug The debug flag.
+     * @return void
+     */
+    protected function setDebug($debug)
+    {
+        $this->debug = !!$debug;
+    }
+
+    /**
+     * Retrieve the application debug mode.
+     *
+     * @return boolean
+     */
+    public function debug()
+    {
+        return $this->debug;
+    }
+
+    /**
+     * Set the admin's configset.
+     *
+     * @param  AdminConfig $config A configset.
+     * @return void
+     */
+    protected function setAdminConfig(AdminConfig $config)
+    {
+        $this->adminConfig = $config;
+    }
+
+    /**
+     * Retrieve the admin's configset.
+     *
+     * @param  string|null $key     Optional data key to retrieve from the configset.
+     * @param  mixed|null  $default The default value to return if data key does not exist.
+     * @return mixed|AdminConfig
+     */
+    protected function adminConfig($key = null, $default = null)
+    {
+        if ($key) {
+            if (isset($this->adminConfig[$key])) {
+                return $this->adminConfig[$key];
+            } else {
+                if (!is_string($default) && is_callable($default)) {
+                    return $default();
+                } else {
+                    return $default;
+                }
+            }
+        }
+
+        return $this->adminConfig;
+    }
+
+    /**
+     * Set the application's configset.
+     *
+     * @param  AppConfig $config A configset.
+     * @return void
+     */
+    protected function setAppConfig(AppConfig $config)
+    {
+        $this->appConfig = $config;
+    }
+
+    /**
+     * Retrieve the application's configset.
+     *
+     * @param  string|null $key     Optional data key to retrieve from the configset.
+     * @param  mixed|null  $default The default value to return if data key does not exist.
+     * @return mixed|AppConfig
+     */
+    protected function appConfig($key = null, $default = null)
+    {
+        if ($key) {
+            if (isset($this->appConfig[$key])) {
+                return $this->appConfig[$key];
+            } else {
+                if (!is_string($default) && is_callable($default)) {
+                    return $default();
+                } else {
+                    return $default;
+                }
+            }
+        }
+
+        return $this->appConfig;
+    }
+}

--- a/src/Charcoal/Admin/Support/BaseUrlTrait.php
+++ b/src/Charcoal/Admin/Support/BaseUrlTrait.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Charcoal\Admin\Support;
+
+use RuntimeException;
+
+// From PSR-7
+use Psr\Http\Message\UriInterface;
+
+/**
+ * URI Support Trait
+ */
+trait BaseUrlTrait
+{
+    /**
+     * The base URI.
+     *
+     * @var UriInterface
+     */
+    protected $baseUrl;
+
+    /**
+     * The base admin URI.
+     *
+     * @var UriInterface
+     */
+    protected $adminUrl;
+
+    /**
+     * Set the base URI of the application.
+     *
+     * @see    \Charcoal\App\ServiceProvider\AppServiceProvider `$container['base-url']`
+     * @param  UriInterface $uri The base URI.
+     * @return self
+     */
+    protected function setBaseUrl(UriInterface $uri)
+    {
+        $this->baseUrl = $uri;
+        return $this;
+    }
+
+    /**
+     * Retrieve the base URI of the application.
+     *
+     * @param  mixed $targetPath Optional target path.
+     * @throws RuntimeException If the base URI is missing.
+     * @return string|null
+     */
+    public function baseUrl($targetPath = null)
+    {
+        if (!isset($this->baseUrl)) {
+            throw new RuntimeException(sprintf(
+                'The base URI is not defined for [%s]',
+                get_class($this)
+            ));
+        }
+
+        if ($targetPath !== null) {
+            return $this->createAbsoluteUrl($this->baseUrl, $targetPath);
+        }
+
+        return rtrim($this->baseUrl, '/').'/';
+    }
+
+    /**
+     * Set the URI of the administration-area.
+     *
+     * @see    \Charcoal\App\ServiceProvider\AdminServiceProvider `$container['admin/base-url']`
+     * @param  UriInterface $uri The base URI.
+     * @return self
+     */
+    protected function setAdminUrl(UriInterface $uri)
+    {
+        $this->adminUrl = $uri;
+        return $this;
+    }
+
+    /**
+     * Retrieve the URI of the administration-area.
+     *
+     * @param  mixed $targetPath Optional target path.
+     * @throws RuntimeException If the admin URI is missing.
+     * @return UriInterface|null
+     */
+    public function adminUrl($targetPath = null)
+    {
+        if (!isset($this->adminUrl)) {
+            throw new RuntimeException(sprintf(
+                'The Admin URI is not defined for [%s]',
+                get_class($this)
+            ));
+        }
+
+        if ($targetPath !== null) {
+            return $this->createAbsoluteUrl($this->adminUrl, $targetPath);
+        }
+
+        return rtrim($this->adminUrl, '/').'/';
+    }
+
+    /**
+     * Determine if the given URI is relative.
+     *
+     * @param  string $uri A URI path to test.
+     * @return boolean
+     */
+    protected function isRelativeUri($uri)
+    {
+        if ($uri && !parse_url($uri, PHP_URL_SCHEME)) {
+            if (!in_array($uri[0], [ '/', '#', '?' ])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Prepend the base URI to the given path.
+     *
+     * @param  UriInterface $basePath   The base path.
+     * @param  string       $targetPath The target path.
+     * @return UriInterface|string The absolute URI.
+     */
+    protected function createAbsoluteUrl(UriInterface $basePath, $targetPath)
+    {
+        $targetPath = strval($targetPath);
+        if ($targetPath === '') {
+            return $basePath->withPath('');
+        } else {
+            if ($this->isRelativeUri($targetPath)) {
+                $parts = parse_url($targetPath);
+                $path  = isset($parts['path']) ? ltrim($parts['path'], '/') : '';
+                $query = isset($parts['query']) ? $parts['query'] : '';
+                $hash  = isset($parts['fragment']) ? $parts['fragment'] : '';
+                $targetPath = $basePath->withPath($path)->withQuery($query)->withFragment($hash);
+            }
+        }
+
+        return $targetPath;
+    }
+}

--- a/src/Charcoal/Admin/Support/SecurityTrait.php
+++ b/src/Charcoal/Admin/Support/SecurityTrait.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Charcoal\Admin\Support;
+
+/**
+ * Security Support Trait
+ */
+trait SecurityTrait
+{
+    /**
+     * Determine if user authentication is required.
+     *
+     * Authentication is required by default. If unnecessary,
+     * replace this method in the inherited template class.
+     *
+     * For example, the "Login" / "Reset Password" templates
+     * should return `false`.
+     *
+     * @return boolean
+     */
+    protected function authRequired()
+    {
+        return true;
+    }
+
+    /**
+     * Determine if the current user is authenticated.
+     *
+     * @return boolean
+     */
+    public function isAuthenticated()
+    {
+        return !!$this->authenticator()->authenticate();
+    }
+
+    /**
+     * Retrieve the currently authenticated user.
+     *
+     * @return \Charcoal\User\UserInterface|null
+     */
+    public function getAuthenticatedUser()
+    {
+        return $this->authenticator()->authenticate();
+    }
+
+    /**
+     * Retrieve the authentication service.
+     *
+     * @return \Charcoal\User\Authenticator
+     */
+    abstract protected function authenticator();
+}

--- a/src/Charcoal/Admin/Template/LoginTemplate.php
+++ b/src/Charcoal/Admin/Template/LoginTemplate.php
@@ -18,19 +18,12 @@ class LoginTemplate extends AdminTemplate
      */
     public function backgroundImage()
     {
-        if (!isset($this->adminConfig['login'])) {
+        $backdrop = $this->adminConfig('login.background_image');
+        if (empty($backdrop)) {
             return '';
         }
-        $loginConfig = $this->adminConfig['login'];
-        if (!isset($loginConfig['background_image']) || !is_string($loginConfig['background_image'])) {
-            return '';
-        }
-        $bg = $loginConfig['background_image'];
-        if (strstr($bg, 'http')) {
-            return $bg;
-        } else {
-            return $this->baseUrl().$bg;
-        }
+
+        return $this->baseUrl($backdrop);
     }
 
     /**
@@ -40,19 +33,12 @@ class LoginTemplate extends AdminTemplate
      */
     public function backgroundVideo()
     {
-        if (!isset($this->adminConfig['login'])) {
+        $backdrop = $this->adminConfig('login.background_video');
+        if (empty($backdrop)) {
             return '';
         }
-        $loginConfig = $this->adminConfig['login'];
-        if (!isset($loginConfig['background_video']) || !is_string($loginConfig['background_video'])) {
-            return '';
-        }
-        $bg = $loginConfig['background_video'];
-        if (strstr($bg, 'http')) {
-            return $bg;
-        } else {
-            return $this->baseUrl().$bg;
-        }
+
+        return $this->baseUrl($backdrop);
     }
 
     /**
@@ -60,11 +46,14 @@ class LoginTemplate extends AdminTemplate
      */
     public function loginLogo()
     {
-        if (isset($this->adminConfig['login_logo'])) {
-            return $this->adminConfig['login_logo'];
-        } else {
-            return $this->baseUrl().'assets/admin/images/avatar.jpg';
+        $logo = $this->adminConfig('login.logo') ?:
+                $this->adminConfig('login_logo', 'assets/admin/images/avatar.jpg');
+
+        if (empty($logo)) {
+            return '';
         }
+
+        return $this->baseUrl($logo);
     }
 
     /**
@@ -130,7 +119,7 @@ class LoginTemplate extends AdminTemplate
      */
     public function urlLoginAction()
     {
-        return $this->adminUrl().'login';
+        return $this->adminUrl('login');
     }
 
     /**
@@ -138,7 +127,7 @@ class LoginTemplate extends AdminTemplate
      */
     public function urlLostPassword()
     {
-        return $this->adminUrl().'account/lost-password';
+        return $this->adminUrl('account/lost-password');
     }
 
     /**

--- a/src/Charcoal/Admin/Template/LogoutTemplate.php
+++ b/src/Charcoal/Admin/Template/LogoutTemplate.php
@@ -79,11 +79,14 @@ class LogoutTemplate extends AdminTemplate
      */
     public function logoutLogo()
     {
-        if (isset($this->adminConfig['logout_logo'])) {
-            return $this->adminConfig['logout_logo'];
-        } else {
-            return $this->baseUrl().'assets/admin/images/avatar.jpg';
+        $logo = $this->adminConfig('logout.logo') ?:
+                $this->adminConfig('logout_logo', 'assets/admin/images/avatar.jpg');
+
+        if (empty($logo)) {
+            return '';
         }
+
+        return $this->baseUrl($logo);
     }
 
     /**

--- a/src/Charcoal/Admin/Ui/Sidemenu/SidemenuGroupTrait.php
+++ b/src/Charcoal/Admin/Ui/Sidemenu/SidemenuGroupTrait.php
@@ -201,8 +201,6 @@ trait SidemenuGroupTrait
             );
         }
 
-        $objType = $this->sidemenu()->objType();
-
         if (is_array($link)) {
             $active = true;
             $name = null;
@@ -229,7 +227,7 @@ trait SidemenuGroupTrait
                 return $this;
             }
 
-            $isSelected = ($linkIdent === $objType);
+            $isSelected = $this->sidemenu()->isCurrentItem([ $linkIdent, (string)$url ]);
 
             if ($isSelected) {
                 $this->isSelected(true);

--- a/src/Charcoal/Admin/Widget/SidemenuWidget.php
+++ b/src/Charcoal/Admin/Widget/SidemenuWidget.php
@@ -173,7 +173,7 @@ class SidemenuWidget extends AdminWidget implements
      */
     public function adminSidemenu()
     {
-        return $this->adminConfig['sidemenu'];
+        return $this->adminConfig('sidemenu', []);
     }
 
     /**
@@ -185,7 +185,7 @@ class SidemenuWidget extends AdminWidget implements
     {
         if ($this->adminRoute === null) {
             $uri = $this->httpRequest()->getUri();
-            $uri = $uri->withBasePath($this->adminConfig['base_path']);
+            $uri = $uri->withBasePath($this->adminConfig('base_path'));
 
             $path = str_replace($uri->getBasePath(), '', $uri->getPath());
             $path = ltrim($path, '/');


### PR DESCRIPTION
tl;dr
- Grouped duplicate code into a collection of support traits (configs, URLs, auth)
- Added support to more easily highlight a header / sidemenu menu item from the template data.

ts;wm

Changes:
- Added [`Support`](src/Charcoal/Admin/Support) namespace
- Added [`AdminTrait`](src/Charcoal/Admin/Support/AdminTrait.php) to handle dev mode, admin config, and app config
- Added [`BaseUrlTrait`](src/Charcoal/Admin/Support/BaseUrlTrait.php) to handle site URLs and admin URLs
- Added [`SecurityTrait`](src/Charcoal/Admin/Support/SecurityTrait.php) to handle conditional auth checks
- Added "current_item" implementation to SidemenuWidget and SidemenuGroupTrait
- Added "header_menu_item", "side_menu_item", and "system_menu_item" to AdminTemplate
