### PR TITLE
Add charcoal-cms dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "barryvdh/elfinder-flysystem-driver": "^0.2.1",
         "locomotivemtl/charcoal-app": "~0.8.1",
         "locomotivemtl/charcoal-cache": "~0.1",
+        "locomotivemtl/charcoal-cms": "~0.8",
         "locomotivemtl/charcoal-core": "~0.4",
         "locomotivemtl/charcoal-email": "~0.3",
         "locomotivemtl/charcoal-object": "~0.6",


### PR DESCRIPTION
[Charcoal\Admin\Service\SelectizeRenderer](https://github.com/locomotivemtl/charcoal-admin/blob/master/src/Charcoal/Admin/Service/SelectizeRenderer.php) uses `Charcoal\Cms\TemplateableTrait`