### PR TITLE
Improve handling of form properties in form widgets

### DIFF
--- a/src/Charcoal/Admin/Widget/FormPropertyWidget.php
+++ b/src/Charcoal/Admin/Widget/FormPropertyWidget.php
@@ -35,6 +35,7 @@ class FormPropertyWidget extends AdminWidget implements
     FormInputInterface
 {
     const HIDDEN_FORM_CONTROL     = 'charcoal/admin/property/input/hidden';
+    const READONLY_FORM_CONTROL   = 'charcoal/admin/property/input/readonly';
     const DEFAULT_FORM_CONTROL    = 'charcoal/admin/property/input/text';
 
     const PROPERTY_CONTROL = 'input';
@@ -750,6 +751,14 @@ class FormPropertyWidget extends AdminWidget implements
     public function hidden()
     {
         return ($this->inputType() === static::HIDDEN_FORM_CONTROL || $this->property()['hidden']);
+    }
+
+    /**
+     * @return boolean
+     */
+    public function editable()
+    {
+        return ($this->inputType() !== static::READONLY_FORM_CONTROL && $this->outputType() === static::PROPERTY_CONTROL);
     }
 
     /**

--- a/src/Charcoal/Admin/Widget/FormSidebarWidget.php
+++ b/src/Charcoal/Admin/Widget/FormSidebarWidget.php
@@ -113,6 +113,20 @@ class FormSidebarWidget extends AdminWidget implements
     protected $showFooter = true;
 
     /**
+     * Whether to display the sidebar actions.
+     *
+     * @var boolean
+     */
+    protected $showSidebarActions;
+
+    /**
+     * Whether to display the language switcher.
+     *
+     * @var boolean
+     */
+    protected $showLanguageSwitch;
+
+    /**
      * Whether the object is viewable.
      *
      * @var boolean
@@ -330,11 +344,21 @@ class FormSidebarWidget extends AdminWidget implements
      */
     public function showSidebarActions()
     {
-        $actions = array_filter($this->sidebarActions(), function($action) {
-            return $action['active'] === true;
-        });
+        if ($this->showSidebarActions === null) {
+            $actions = $this->sidebarActions();
+            if (empty($actions)) {
+                return false;
+            }
 
-        return count($actions) > 0;
+            $actions = array_filter($actions, function($action) {
+                return $action['active'] === true;
+            });
+
+            $this->showSidebarActions = (count($actions) > 0);
+        }
+
+        return $this->showSidebarActions;
+
     }
 
     /**
@@ -778,18 +802,23 @@ class FormSidebarWidget extends AdminWidget implements
      */
     public function showLanguageSwitch()
     {
-        if ($this->form()) {
-            $locales = count($this->translator()->availableLocales());
-            if ($locales > 1) {
-                foreach ($this->form()->formProperties() as $formProp) {
-                    if ($formProp->property()['l10n']) {
-                        return true;
+        if ($this->showLanguageSwitch === null) {
+            if ($this->form()) {
+                $locales = count($this->translator()->availableLocales());
+                if ($locales > 1) {
+                    foreach ($this->form()->getFormProperties() as $formProp) {
+                        if ($formProp->property()['l10n']) {
+                            $this->showLanguageSwitch = true;
+                            return $this->showLanguageSwitch;
+                        }
                     }
                 }
             }
+
+            $this->showLanguageSwitch = false;
         }
 
-        return false;
+        return $this->showLanguageSwitch;
     }
 
     /**

--- a/src/Charcoal/Admin/Widget/FormSidebarWidget.php
+++ b/src/Charcoal/Admin/Widget/FormSidebarWidget.php
@@ -358,7 +358,6 @@ class FormSidebarWidget extends AdminWidget implements
         }
 
         return $this->showSidebarActions;
-
     }
 
     /**

--- a/src/Charcoal/Admin/Widget/FormWidget.php
+++ b/src/Charcoal/Admin/Widget/FormWidget.php
@@ -135,8 +135,9 @@ class FormWidget extends AdminWidget implements
     }
 
     /**
-     * @param string $ident Property ident.
-     * @param array  $data  Property metadata.
+     * @param  string $ident Property ident.
+     * @param  array  $data  Property metadata.
+     * @throws InvalidArgumentException If the property is already registered.
      * @return \Charcoal\Admin\Widget\FormPropertyWidget|mixed
      */
     public function getOrCreateFormProperty($ident, array $data = null)
@@ -170,8 +171,9 @@ class FormWidget extends AdminWidget implements
     }
 
     /**
-     * @param string $ident Property ident.
-     * @param array  $data  Property metadata.
+     * @param  string $ident Property ident.
+     * @param  array  $data  Property metadata.
+     * @throws InvalidArgumentException If the property is already registered.
      * @return \Charcoal\Admin\Widget\FormPropertyWidget|mixed
      */
     public function getOrCreateHiddenProperty($ident, array $data = null)
@@ -253,8 +255,8 @@ class FormWidget extends AdminWidget implements
     }
 
     /**
-     * @param string $ident Property ident.
-     * @param array  $data  Property metadata.
+     * @param  string $ident Property ident.
+     * @param  array  $data  Property metadata.
      * @return \Charcoal\Admin\Widget\FormPropertyWidget|null
      */
     protected function updateHiddenProperty($ident, array $data = null)

--- a/src/Charcoal/Admin/Widget/FormWidget.php
+++ b/src/Charcoal/Admin/Widget/FormWidget.php
@@ -364,6 +364,25 @@ class FormWidget extends AdminWidget implements
     }
 
     /**
+     * Retrieve the form's property controls.
+     *
+     * @return FormPropertyWidget[]
+     */
+    public function getFormProperties()
+    {
+        $formProperties = [];
+        foreach ($this->formProperties as $formProperty) {
+            if ($formProperty->active() === false) {
+                continue;
+            }
+
+            $formProperties[$formProperty->propertyIdent()] = $formProperty;
+        }
+
+        return $formProperties;
+    }
+
+    /**
      * Replace hidden property controls to the form.
      *
      * @param  array $properties The hidden form properties.

--- a/src/Charcoal/Admin/Widget/ObjectFormWidget.php
+++ b/src/Charcoal/Admin/Widget/ObjectFormWidget.php
@@ -207,7 +207,9 @@ class ObjectFormWidget extends FormWidget implements
         // We need to sort form properties by form group property order if a group exists
         if (!empty($group)) {
             $group = array_map([ $this, 'camelize' ], $group);
-            $props = array_merge(array_flip($group), $props);
+            $group = array_flip($group);
+            $props = array_intersect_key($props, $group);
+            $props = array_merge($group, $props);
         }
 
         foreach ($props as $propertyIdent => $propertyMetadata) {


### PR DESCRIPTION
This request fixes various issues and side-effects. No breaking changes.

Added support for registering an object property more than once with detection to ensure input properties don't conflict.

For example, a model has a `category` property; you can add a hidden input property and add a display property. If you added another input property, an exception would be thrown.

---

Side-effects caused by calling `ObjectFormWidget::formProperties()`:

- Registering the form property dynamic templates in `FormWidget`
- Looking up which properties are L10N in `FormSidebarWidget` triggers,
- On-the-fly creation of form properties in `ObjectFormWidget`

---

Added:
- Method `FormWidget::getFormProperties()` to allow interaction with registered form properties without triggering side-effects
- Class properties to `FormSidebarWidget` to store the result of `showSidebarActions()` and `showLanguageSwitch()` methods

Fixed:
- Method `ObjectFormWidget::formProperties()` to intersect any properties from `$group` parameter to avoid processing all object properties

Changed:
- Decoupled method `FormWidget::getOrCreateFormProperty()` to distinguish visible vs hidden form properties and allow for greater customization in sub-classes of `FormWidget`
- Method `FormSidebarWidget::showLanguageSwitch()` to use new `FormWidget::getFormProperties()` method (prevents side-effects)