### PR TITLE
[WIP] Improve registration of Form Properties in FormWidget

### DIFF
--- a/src/Charcoal/Admin/Docs/Widget/DocFormPropertyWidget.php
+++ b/src/Charcoal/Admin/Docs/Widget/DocFormPropertyWidget.php
@@ -9,6 +9,8 @@ use Charcoal\Admin\Widget\FormPropertyWidget;
  */
 class DocFormPropertyWidget extends FormPropertyWidget
 {
+    const DEFAULT_TYPE = 'charcoal/admin/docs/widget/form-property-widget';
+
     /**
      * @var array
      */

--- a/src/Charcoal/Admin/Ui/FormPropertyInterface.php
+++ b/src/Charcoal/Admin/Ui/FormPropertyInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Charcoal\Admin\Ui;
+
+/**
+ * Defines an admin form sidebar
+ */
+interface FormPropertyInterface
+{
+}

--- a/src/Charcoal/Admin/Widget/DocWidget.php
+++ b/src/Charcoal/Admin/Widget/DocWidget.php
@@ -349,9 +349,8 @@ class DocWidget extends FormWidget implements
             $formProperty->setData($propertyMetadata);
             $formProperty->setPropertyVal($obj[$propertyIdent]);
 
-            if ($formProperty->hidden()) {
-                $this->hiddenProperties[$propertyIdent] = $formProperty;
-            } else {
+            if (!$formProperty->hidden()) {
+                $this->setDynamicTemplate('form_property_widget', $formProperty->template());
                 yield $propertyIdent => $formProperty;
             }
         }

--- a/src/Charcoal/Admin/Widget/FormPropertyWidget.php
+++ b/src/Charcoal/Admin/Widget/FormPropertyWidget.php
@@ -25,6 +25,7 @@ use Charcoal\Ui\FormInput\FormInputInterface;
 
 // From 'charcoal-admin'
 use Charcoal\Admin\AdminWidget;
+use Charcoal\Admin\Ui\FormPropertyInterface;
 
 /**
  * Form Control Widget
@@ -32,6 +33,7 @@ use Charcoal\Admin\AdminWidget;
  * For model properties.
  */
 class FormPropertyWidget extends AdminWidget implements
+    FormPropertyInterface,
     FormInputInterface
 {
     const HIDDEN_FORM_CONTROL     = 'charcoal/admin/property/input/hidden';
@@ -42,12 +44,21 @@ class FormPropertyWidget extends AdminWidget implements
     const PROPERTY_DISPLAY = 'display';
     const DEFAULT_OUTPUT   = self::PROPERTY_CONTROL;
 
+    const DEFAULT_TYPE = 'charcoal/admin/widget/form-property-widget';
+
     /**
      * The widget's type.
      *
      * @var string|null
      */
     protected $type;
+
+    /**
+     * The widget's template.
+     *
+     * @var string $template
+     */
+    protected $template;
 
     /**
      * The widget's property output type.
@@ -207,57 +218,6 @@ class FormPropertyWidget extends AdminWidget implements
     private $icon;
 
     /**
-     * Retrieve the property factory.
-     *
-     * @throws RuntimeException If the property factory is missing.
-     * @return FactoryInterface
-     */
-    public function propertyFactory()
-    {
-        if ($this->propertyFactory === null) {
-            throw new RuntimeException(
-                'Missing Property Factory'
-            );
-        }
-
-        return $this->propertyFactory;
-    }
-
-    /**
-     * Retrieve the property control factory.
-     *
-     * @throws RuntimeException If the property control factory is missing.
-     * @return FactoryInterface
-     */
-    public function propertyInputFactory()
-    {
-        if ($this->propertyInputFactory === null) {
-            throw new RuntimeException(
-                'Missing Property Input Factory'
-            );
-        }
-
-        return $this->propertyInputFactory;
-    }
-
-    /**
-     * Retrieve the property display factory.
-     *
-     * @throws RuntimeException If the property display factory is missing.
-     * @return FactoryInterface
-     */
-    public function propertyDisplayFactory()
-    {
-        if ($this->propertyDisplayFactory === null) {
-            throw new RuntimeException(
-                'Missing Property Display Factory'
-            );
-        }
-
-        return $this->propertyDisplayFactory;
-    }
-
-    /**
      * Retrieve the widget ID.
      *
      * @return string
@@ -307,6 +267,69 @@ class FormPropertyWidget extends AdminWidget implements
         $this->type = $type;
 
         return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function template()
+    {
+        if ($this->template === null) {
+            return static::DEFAULT_TYPE;
+        }
+
+        return $this->template;
+    }
+
+    /**
+     * Retrieve the property factory.
+     *
+     * @throws RuntimeException If the property factory is missing.
+     * @return FactoryInterface
+     */
+    public function propertyFactory()
+    {
+        if ($this->propertyFactory === null) {
+            throw new RuntimeException(
+                'Missing Property Factory'
+            );
+        }
+
+        return $this->propertyFactory;
+    }
+
+    /**
+     * Retrieve the property control factory.
+     *
+     * @throws RuntimeException If the property control factory is missing.
+     * @return FactoryInterface
+     */
+    public function propertyInputFactory()
+    {
+        if ($this->propertyInputFactory === null) {
+            throw new RuntimeException(
+                'Missing Property Input Factory'
+            );
+        }
+
+        return $this->propertyInputFactory;
+    }
+
+    /**
+     * Retrieve the property display factory.
+     *
+     * @throws RuntimeException If the property display factory is missing.
+     * @return FactoryInterface
+     */
+    public function propertyDisplayFactory()
+    {
+        if ($this->propertyDisplayFactory === null) {
+            throw new RuntimeException(
+                'Missing Property Display Factory'
+            );
+        }
+
+        return $this->propertyDisplayFactory;
     }
 
     /**

--- a/src/Charcoal/Admin/Widget/FormWidget.php
+++ b/src/Charcoal/Admin/Widget/FormWidget.php
@@ -466,17 +466,12 @@ class FormWidget extends AdminWidget implements
      */
     public function formProperties()
     {
-        $sidebars = $this->sidebars;
-        if (!is_array($sidebars)) {
-            yield null;
-        } else {
-            foreach ($this->formProperties as $formProperty) {
-                if ($formProperty->active() === false) {
-                    continue;
-                }
-                $this->setDynamicTemplate('widget_template', $formProperty->inputType());
-                yield $formProperty->propertyIdent() => $formProperty;
+        foreach ($this->formProperties as $formProperty) {
+            if ($formProperty->active() === false) {
+                continue;
             }
+            $this->setDynamicTemplate('form_property_widget', $formProperty->template());
+            yield $formProperty->propertyIdent() => $formProperty;
         }
     }
 

--- a/src/Charcoal/Admin/Widget/ObjectFormWidget.php
+++ b/src/Charcoal/Admin/Widget/ObjectFormWidget.php
@@ -231,6 +231,7 @@ class ObjectFormWidget extends FormWidget implements
 
             $formProperty = $this->getOrCreateFormProperty($propertyIdent, $propertyMetadata);
             if ($formProperty && !$formProperty->hidden()) {
+                $this->setDynamicTemplate('form_property_widget', $formProperty->template());
                 yield $propertyIdent => $formProperty;
             }
         }

--- a/src/Charcoal/Admin/Widget/ObjectFormWidget.php
+++ b/src/Charcoal/Admin/Widget/ObjectFormWidget.php
@@ -230,8 +230,7 @@ class ObjectFormWidget extends FormWidget implements
             }
 
             $formProperty = $this->getOrCreateFormProperty($propertyIdent, $propertyMetadata);
-
-            if (!$formProperty->hidden()) {
+            if ($formProperty && !$formProperty->hidden()) {
                 yield $propertyIdent => $formProperty;
             }
         }
@@ -397,7 +396,10 @@ class ObjectFormWidget extends FormWidget implements
      */
     protected function defaultDataSources()
     {
-        return [static::DATA_SOURCE_REQUEST, static::DATA_SOURCE_OBJECT];
+        return [
+            static::DATA_SOURCE_REQUEST,
+            static::DATA_SOURCE_OBJECT,
+        ];
     }
 
     /**

--- a/templates/charcoal/admin/docs/widget/form-group-widget.mustache
+++ b/templates/charcoal/admin/docs/widget/form-group-widget.mustache
@@ -28,7 +28,7 @@
     {{/ showHeader }}
     {{# formProperties }}
         <div class="mb-4">
-            {{> charcoal/admin/docs/widget/form-property-widget }}
+            {{> $form_property_widget }}
         </div>
     {{/ formProperties }}
 </div>

--- a/templates/charcoal/admin/widget/form-group/form-properties.mustache
+++ b/templates/charcoal/admin/widget/form-group/form-properties.mustache
@@ -16,7 +16,7 @@
     {{/ layout }}
 
             <div{{# layout }} class="col-md-{{ cellSpanBy12 }}"{{/ layout }}>
-                {{> charcoal/admin/widget/form-property-widget }}
+                {{> $form_property_widget }}
             </div>
 
     {{# layout }}


### PR DESCRIPTION
Added:
- Support for creating custom form property widget via "widget_type"
- Support for NOT creating form property widgets

Changed:
- Renamed dynamic partial 'widget_template' to 'form_property_widget'
- Improved exception messages for form properties
- Cleaned up block comments

Fixed:
- Unnecessary reassignment in methods `updateFormProperty()` and `updateHiddenProperty()` on `FormWidget`