### PR TITLE
Replace ACL component from Zend with Laminas

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ composer require locomotivemtl/charcoal-admin
 -   [locomotivemtl/charcoal-object](https://github.com/locomotivemtl/charcoal-object)
     -   Object definition (Content and UserData), behaviors and tools.
 -	[locomotivemtl/charcoal-user](https://github.com/locomotivemtl/charcoal-user)
-	-	User defintion (as Charcoal Model), authentication and authorization (with Zend ACL).
+	-	User defintion (as Charcoal Model), authentication and authorization (with Laminas ACL).
 
 > 👉 Development dependencies are described in the _Development_ section of this README file.
 

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "barryvdh/elfinder-flysystem-driver": "^0.2.1",
         "guzzlehttp/guzzle": "^6.3",
         "kriswallsmith/assetic": "^1.4",
+        "laminas/laminas-permissions-acl": "^2.7",
         "locomotivemtl/charcoal-app": "~0.8.1",
         "locomotivemtl/charcoal-cache": "~0.1",
         "locomotivemtl/charcoal-cms": "~0.8",

--- a/src/Charcoal/Admin/ServiceProvider/AclServiceProvider.php
+++ b/src/Charcoal/Admin/ServiceProvider/AclServiceProvider.php
@@ -6,9 +6,9 @@ namespace Charcoal\Admin\ServiceProvider;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 
-// From 'zendframework/zend-permissions'
-use Zend\Permissions\Acl\Acl;
-use Zend\Permissions\Acl\Resource\GenericResource as AclResource;
+// From 'laminas/laminas-permissions-acl'
+use Laminas\Permissions\Acl\Acl;
+use Laminas\Permissions\Acl\Resource\GenericResource as AclResource;
 
 // From 'charcoal-user'
 use Charcoal\User\Acl\Manager as AclManager;
@@ -20,7 +20,7 @@ use Charcoal\User\Acl\Manager as AclManager;
  *
  * ## Services
  *
- * - `admin/acl` A Zend ACL instance containing the admin resources / permissions.
+ * - `admin/acl` A Laminas ACL instance containing the admin resources / permissions.
  *
  * ## Dependencies
  *

--- a/src/Charcoal/Admin/Widget/FormGroup/AclPermissions.php
+++ b/src/Charcoal/Admin/Widget/FormGroup/AclPermissions.php
@@ -8,10 +8,10 @@ use RuntimeException;
 // From Pimple
 use Pimple\Container;
 
-// From 'zendframework/zend-permissions-acl'
-use Zend\Permissions\Acl\Acl;
-use Zend\Permissions\Acl\Role\GenericRole as Role;
-use Zend\Permissions\Acl\Resource\GenericResource as Resource;
+// From 'laminas/laminas-permissions-acl'
+use Laminas\Permissions\Acl\Acl;
+use Laminas\Permissions\Acl\Role\GenericRole as Role;
+use Laminas\Permissions\Acl\Resource\GenericResource as Resource;
 
 // From 'charcoal-core'
 use Charcoal\Loader\CollectionLoader;

--- a/tests/Charcoal/Admin/ContainerProvider.php
+++ b/tests/Charcoal/Admin/ContainerProvider.php
@@ -16,8 +16,8 @@ use Slim\Http\Uri;
 // From 'tedivm/stash' (PSR-6)
 use Stash\Pool;
 
-// From 'zendframework/zend-permissions-acl'
-use Zend\Permissions\Acl\Acl;
+// From 'laminas/laminas-permissions-acl'
+use Laminas\Permissions\Acl\Acl;
 
 // From Pimple
 use Pimple\Container;


### PR DESCRIPTION
Related:

- locomotivemtl/charcoal-user#5

---

Replaced `zendframework/zend-permissions-acl` with `laminas/laminas-permissions-acl`, as per:

The Zend Framework is migrating to the Laminas-branded framework ([source](https://www.zend.com/blog/evolution-zend-framework-laminas-project)).
