### PR TITLE
Lost Password Email - add new config options

### DIFF
--- a/config/admin.config.default.json
+++ b/config/admin.config.default.json
@@ -253,30 +253,15 @@
         }
     },
 
-    "user": {
-        "subscription_email": {
-            "active": true,
-            "template": "charcoal/admin/email/user.subscription",
-            "campaign": "admin.user.subscription",
-            "from": {
-                "name": "Charcoal",
-                "email": "registration@charcoal.locomotive.ca"
-            },
-            "subject": "Your subscription to Charcoal",
-            "log": true,
-            "track": true
-        },
+    "email": {
         "lost_password_email": {
-            "active": true,
-            "template": "charcoal/admin/email/user.lost-password",
-            "campaign": "admin.user.lost-password",
+            "template_ident": "charcoal/admin/email/user.lost-password",
+            "campaign": "admin.lost-password",
             "from": {
                 "name": "Charcoal",
-                "email": "registration@charcoal.locomotive.ca"
+                "email": "charcoal@locomotive.ca"
             },
-            "subject": "Reset your Charcoal password",
-            "log": true,
-            "track": true
+            "log": true
         }
     },
 

--- a/config/admin.config.default.json
+++ b/config/admin.config.default.json
@@ -253,7 +253,19 @@
         }
     },
 
-    "email": {
+    "user": {
+        "subscription_email": {
+            "active": true,
+            "template": "charcoal/admin/email/user.subscription",
+            "campaign": "admin.user.subscription",
+            "from": {
+                "name": "Charcoal",
+                "email": "registration@charcoal.locomotive.ca"
+            },
+            "subject": "Your subscription to Charcoal",
+            "log": true,
+            "track": true
+        },
         "lost_password_email": {
             "template_ident": "charcoal/admin/email/user.lost-password",
             "campaign": "admin.lost-password",

--- a/src/Charcoal/Admin/Action/Account/LostPasswordAction.php
+++ b/src/Charcoal/Admin/Action/Account/LostPasswordAction.php
@@ -238,7 +238,7 @@ class LostPasswordAction extends AdminAction
      */
     private function sendLostPasswordEmail(User $user, $token)
     {
-        $emailConfig = $this->adminConfig('email')['lost_password_email'];
+        $emailConfig = $this->adminConfig('user')['lost_password_email'];
         $translator  = $this->translator();
         $userEmail   = $user['email'];
         $siteName    = $this->siteName();

--- a/src/Charcoal/Admin/Action/Account/LostPasswordAction.php
+++ b/src/Charcoal/Admin/Action/Account/LostPasswordAction.php
@@ -232,16 +232,16 @@ class LostPasswordAction extends AdminAction
     }
 
     /**
-     * @todo   Implement `$container['admin/config']['user.lost_password_email']`
      * @param  User   $user  The user to send the lost-password email to.
-     * @param  string $token The lost-password token, as string.
+     * @param  LostPasswordToken $token The lost-password token, as string.
      * @return void
      */
     private function sendLostPasswordEmail(User $user, $token)
     {
-        $translator = $this->translator();
-        $userEmail  = $user['email'];
-        $siteName   = $this->siteName();
+        $emailConfig = $this->adminConfig('email')['lost_password_email'];
+        $translator  = $this->translator();
+        $userEmail   = $user['email'];
+        $siteName    = $this->siteName();
 
         if ($siteName) {
             $subject = strtr($translator->translate('{{ siteName }} — Password Reset'), [
@@ -251,20 +251,11 @@ class LostPasswordAction extends AdminAction
             $subject = $translator->translate('Charcoal — Password Reset');
         }
 
-        $from = [
-            'name'  => 'Charcoal',
-            'email' => 'charcoal@locomotive.ca'
-        ];
-
         // Create email
         $emailObj = $this->emailFactory->create('email');
-        $emailObj->setData([
-            'campaign'          => 'admin.lost-password',
+        $emailObj->setData(array_merge([
             'to'                => $userEmail,
             'subject'           => (string)$subject,
-            'from'              => $from,
-            'log'               => true,
-            'template_ident'    => 'charcoal/admin/email/user.lost-password',
             'template_data'     => [
                 'user'             => $user,
                 'token'            => $token->id(),
@@ -274,7 +265,7 @@ class LostPasswordAction extends AdminAction
                 'expiry'           => $token->expiry()->format('Y-m-d H:i:s'),
                 'ipAddress'        => isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : '',
             ],
-        ]);
+        ], $emailConfig));
         $emailObj->send();
     }
 }


### PR DESCRIPTION
This pull request adds support for changing the default options for the lost password email. Options can be changed using the charcoal admin config.
# New Config Options
```JSON
{
    "admin": {
        "email": {
            "lost_password_email": {
                "template_ident": "charcoal/admin/email/user.lost-password",
                "campaign": "admin.lost-password",
                "from": {
                    "name": "Charcoal",
                    "email": "charcoal@locomotive.ca"
                },
                "log": true
            }
        }
    }
}
```
